### PR TITLE
Sync Tested-up-to bump to WordPress.org SVN inline

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -86,12 +86,12 @@ jobs:
                   branch: chore/tested-up-to-${{ steps.wp.outputs.version }}
                   delete-branch: true
 
-            - name: Auto-merge PR
+            - name: Merge PR
               if: steps.pr.outputs.pull-request-number
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  gh pr merge --auto --squash --delete-branch "${{ steps.pr.outputs.pull-request-number }}"
+                  gh pr merge --squash --delete-branch "${{ steps.pr.outputs.pull-request-number }}"
 
             - name: Sync readme to WordPress.org SVN
               if: steps.pr.outputs.pull-request-number

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -86,15 +86,31 @@ jobs:
                   branch: chore/tested-up-to-${{ steps.wp.outputs.version }}
                   delete-branch: true
 
-            - name: Merge PR
+            - name: Auto-merge PR and wait
               if: steps.pr.outputs.pull-request-number
+              shell: bash
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR: ${{ steps.pr.outputs.pull-request-number }}
               run: |
-                  gh pr merge --squash --delete-branch "${{ steps.pr.outputs.pull-request-number }}"
+                  set -euo pipefail
+                  # Enable auto-merge so the PR queues if any required checks are added later.
+                  gh pr merge --auto --squash --delete-branch "$PR"
+                  # Wait for the merge to actually complete before downstream steps run,
+                  # so the SVN sync below cannot publish ahead of trunk.
+                  for _ in $(seq 1 60); do
+                      merged_at=$(gh pr view "$PR" --json mergedAt --jq '.mergedAt')
+                      if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then
+                          echo "PR #$PR merged at $merged_at"
+                          exit 0
+                      fi
+                      sleep 10
+                  done
+                  echo "PR #$PR did not merge within 10 minutes" >&2
+                  exit 1
 
             - name: Sync readme to WordPress.org SVN
-              if: steps.pr.outputs.pull-request-number
+              if: success() && steps.pr.outputs.pull-request-number
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
     update:
+        if: github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -75,6 +76,7 @@ jobs:
               id: pr
               uses: peter-evans/create-pull-request@v8
               with:
+                  base: trunk
                   commit-message: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
                   title: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
                   body: |
@@ -90,3 +92,11 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   gh pr merge --auto --squash --delete-branch "${{ steps.pr.outputs.pull-request-number }}"
+
+            - name: Sync readme to WordPress.org SVN
+              if: steps.pr.outputs.pull-request-number
+              uses: 10up/action-wordpress-plugin-asset-update@stable
+              env:
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  IGNORE_OTHER_FILES: true


### PR DESCRIPTION
Brings this repo's already-merged `update-tested-up-to.yml` in line with the rest of the cohort:

- Adds an inline `10up/action-wordpress-plugin-asset-update@stable` step (with `IGNORE_OTHER_FILES: true`) so the cron-driven readme bump actually reaches WordPress.org. Without this, the bump merges to `trunk` but `push-asset-readme-update.yml` is not triggered (`GITHUB_TOKEN`-driven pushes don't fire downstream workflows), so WordPress.org would never see the new `Tested up to` value.
- Adds the job-level `if: github.ref == 'refs/heads/trunk'` guard.
- Adds explicit `base: trunk` on `peter-evans/create-pull-request`.

Identical to the workflow on the still-open install PRs in the other 9 plugin repos.