### PR TITLE
Sync .wordpress-org assets so the Playground blueprint reaches the plugin directory

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -12,7 +12,6 @@ jobs:
             - name: WordPress.org plugin asset/readme update
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:
-                  SKIP_ASSETS: true
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
                   README_NAME: README.md


### PR DESCRIPTION
## Summary
- The Playground blueprint at \`.wordpress-org/blueprints/blueprint.json\` was committed to trunk but never appeared on the WordPress.org plugin page — \`push-asset-readme-update.yml\` was setting \`SKIP_ASSETS: true\` on the 10up action, which skips the entire \`.wordpress-org/\` directory.
- Removing the flag lets the action mirror \`.wordpress-org/\` to the plugin's SVN \`assets/\` directory. The SVN \`assets/\` dir doesn't exist yet (confirmed by HTTP 404 on \`plugins.svn.wordpress.org/twenty-eleven-showcase-slider/assets/\`), so this is purely additive — nothing on WordPress.org gets overwritten.
- Future banners, icons, and screenshots dropped into \`.wordpress-org/\` will now sync the same way.

## Test plan
- [ ] Merge to trunk; the \`Plugin asset/readme update\` workflow runs.
- [ ] Confirm \`https://plugins.svn.wordpress.org/twenty-eleven-showcase-slider/assets/blueprints/blueprint.json\` exists after the run.
- [ ] Confirm the **Live Preview** button appears on the plugin's WordPress.org page and opens a working preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)