### PR TITLE
Add required meta.author to blueprint.json

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -2,6 +2,7 @@
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"meta": {
 		"title": "Twenty Eleven Showcase Slider — Live Preview",
+		"author": "obenland",
 		"description": "Sticky featured posts auto-rotate on the Twenty Eleven Showcase template."
 	},
 	"landingPage": "/",


### PR DESCRIPTION
## Summary
- Adds \`meta.author: \"obenland\"\` to the Playground blueprint.
- The blueprint schema marks both \`title\` and \`author\` as required when \`meta\` is present, so omitting \`author\` made WordPress.org's plugin-directory validator reject the blueprint with *\"Missing or invalid blueprint.json file\"* and the Live Preview button never appeared.

## Test plan
- [ ] Merge — the asset-update workflow syncs the corrected blueprint to SVN.
- [ ] WordPress.org re-validates and the warning clears; the **Live Preview** button appears.
- [ ] Drag-and-drop the blueprint onto https://playground.wordpress.net/builder/builder.html — it parses without complaint and runs the carousel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)