### PR TITLE
Point deploy workflow at README.md

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,3 +14,4 @@ jobs:
               env:
                   SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
                   SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+                  README_NAME: README.md


### PR DESCRIPTION
## Summary
- Adds \`README_NAME: README.md\` to \`deploy.yml\`, matching what \`push-asset-readme-update.yml\` already does.
- Without it, the 10up deploy action looks for \`readme.txt\` by default. We don't have one (deliberately — README.md is the single source of truth), so a tag push would either fail or re-create a default \`readme.txt\` and reintroduce the *"License field is missing"* warning we just cleared.

## Test plan
- [ ] Merge, then tag \`4\` — the deploy succeeds and SVN \`/trunk/\` ends up with README.md (Stable tag: 4, License: GPLv2 or later), no stale readme.txt.
- [ ] WordPress.org plugin page reports no warnings after the next import scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)