### PR TITLE
Silence wp-env tests environment deprecation warning

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,6 +3,7 @@
 	"phpVersion": "8.3",
 	"plugins": [ "." ],
 	"themes": [ "https://downloads.wordpress.org/theme/twentyeleven.zip" ],
+	"testsEnvironment": false,
 	"config": {
 		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true,


### PR DESCRIPTION
## Summary

wp-env >= 11.5 deprecated booting a combined dev+tests environment from a single `.wp-env.json` and now prints a deprecation warning on every `wp-env start`.

This repo has **no PHP unit tests** (only Playwright e2e) and its `lifecycleScripts.afterStart` only targets the dev (`cli`) container, so it does not need a separate test config. Setting `"testsEnvironment": false` silences the warning and boots **only** the development environment.

## Change

- `.wp-env.json`: add `"testsEnvironment": false`.

## Verification

- No references to `tests-cli` or `testsPort` anywhere in the repo (workflows, package.json, configs) — nothing relies on a tests environment.
- `npx wp-scripts format .wp-env.json` applied; `node -e "require('./.wp-env.json')"` confirms valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)