### PR TITLE
Bump Tested up to 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: obenland
 Tags: twentyeleven, slider
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3DBDUTYMCVRG4
 Requires at least: 3.1
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress 7.1 is the latest stable release.

Bumps `Tested up to` in README.md from 7.0 to 7.1 (major.minor of 7.1).